### PR TITLE
Usesd npm api to get weekly dowloads count (#50)

### DIFF
--- a/main/management/commands/updatecomponents.py
+++ b/main/management/commands/updatecomponents.py
@@ -27,6 +27,20 @@ def get_npm_data():
     data = json.load(response)
     return data
 
+def get_npm_downloads(url):
+    package=url.split('/')[-1]
+    # dateRange='1980-02-12:'+str(datetime.date(datetime.now()))
+    dateRange='last-week'
+    url='https://api.npmjs.org/downloads/range/'+dateRange+'/'+package
+    hdr = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11'}
+    req = urllib2.Request(url, headers=hdr)
+    response = urllib2.urlopen(req)
+    data = json.load(response)
+    download_count=0
+    for i in data['downloads']:
+        download_count+=i['downloads']
+    return download_count
+
 def send_GET_request(url, user=None, password=None):
     request = urllib2.Request(url)
     if (user is not None and password is not None):
@@ -252,9 +266,9 @@ class Command(BaseCommand):
                 except:
                     print ('Error')
                     continue
-                response = send_GET_request(github_data['downloads_url'], GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET)
-                downloads_array = json.load(response)
-                _component.downloads = len(downloads_array)
+                # response = send_GET_request(github_data['downloads_url'], GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET)
+                # downloads_array = json.load(response)
+                _component.downloads = get_npm_downloads(_component.npm_url)
                 _component.commits = commits
                 _component.no_of_contributors = count
                 _component.save()


### PR DESCRIPTION
I have tested and verified results from http://npmjs.com/package/<packageName> counts 

for [cytoscape](https://www.npmjs.com/package/cytoscape)
* ![screenshot from 2019-02-20 09-54-56](https://user-images.githubusercontent.com/31537546/53087376-011d2b00-352d-11e9-9a03-7294b815b0ae.png)

* ![mnsnp1550661115](https://user-images.githubusercontent.com/31537546/53086766-bcdd5b00-352b-11e9-818d-c27c9a7fc5b6.jpg)
* ![gpjww1550661065](https://user-images.githubusercontent.com/31537546/53086769-bcdd5b00-352b-11e9-8ca7-b1c00d535cab.jpg)

In the cron job, previously it was calculating downloads from github.com which does not reflect right count. I change it to use npm api.

